### PR TITLE
No extra libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Lucene way search in django
-#### ("Django" AND "DRF") OR ("Elasticserach-DSL" AND "Django Rest Elasticsearch")
+#### ("Django" AND "DRF") OR "Elasticserach-DSL"
 
 _________________
 
@@ -24,7 +24,6 @@ pip install lucyfer[full]
 | lucyparser                | +       | +     |
 | Django                    | +       | +     |
 | djangorestframework       | +       | +     |
-| django-rest-elasticsearch | -       | +     |
 | elasticsearch-dsl         | -       | +     |
 
 

--- a/lucyfer/backend/elastic.py
+++ b/lucyfer/backend/elastic.py
@@ -1,9 +1,11 @@
-from rest_framework_elasticsearch.es_filters import BaseEsFilterBackend
-
 from lucyfer.utils import LuceneSearchException
 
+class ElasticLuceneSearchFilterMixin:
+    def get_schema_fields(self, view):
+        assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
+        assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
+        return []
 
-class ElasticLuceneSearchFilterMixin(BaseEsFilterBackend):
     def filter_search(self, request, search, view):
         search_terms = self.get_base_search_terms(request)
 

--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -1,2 +1,1 @@
-django-rest-elasticsearch~=0.4.1
 elasticsearch-dsl~=6.4.0


### PR DESCRIPTION
No need in requiring any version of `django-rest-elasticsearch` as it is archived and contributes actually nothing to the lucyfer